### PR TITLE
Fix typescript rule for no-unused-expressions

### DIFF
--- a/rules/typescript/index.js
+++ b/rules/typescript/index.js
@@ -25,10 +25,16 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": [2, {
       argsIgnorePattern: "^_",
       varsIgnorePattern: "^_",
-    }],    
-    
+    }],
+
+    /**
+     * Disallow unused expressions
+     */
+    'no-unused-expressions': 0,
+    '@typescript-eslint/no-unused-expressions': [2],
+
      /**
-     * Require a specific member delimiter style for interfaces and type literals	
+     * Require a specific member delimiter style for interfaces and type literals
      * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/member-delimiter-style.md
      */
     "@typescript-eslint/member-delimiter-style": 2


### PR DESCRIPTION
This fixes the rule `no-unused-expressions` for use with ts